### PR TITLE
Replace pcregrep With awk And Allow For MAC Address Case Insensitivity

### DIFF
--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -4,13 +4,13 @@
 
 
 # Put the Mac Address of your AirPods in here.
-MACADDR='7c-04-d0-af-88-62'
+MACADDR='1A-2B-3C-4D-5E-6F'
 
 
 # See if we're connected to them
-CONNECTED=`system_profiler SPBluetoothDataType | /usr/local/bin/pcregrep -Mi "$MACADDR(\n.*){6}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
+CONNECTED=`system_profiler SPBluetoothDataType | awk "/$MACADDR/ {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
 if [ $CONNECTED ]; then
-	BTDATA=`defaults read /Library/Preferences/com.apple.Bluetooth | /usr/local/bin/pcregrep -Mi "\"$MACADDR\".=\s*\{[^\}]*\}"`
+	BTDATA=`defaults read /Library/Preferences/com.apple.Bluetooth | awk "/\"$MACADDR\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}"`
 
 	CASEBATT=`echo "$BTDATA" | grep BatteryPercentCase | sed 's/.*BatteryPercentCase = //' | sed 's/;//'` 
 	LEFTBATT=`echo "$BTDATA" | grep BatteryPercentLeft | sed 's/.*BatteryPercentLeft = //' | sed 's/;//'` 

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -8,7 +8,7 @@ MACADDR='1A-2B-3C-4D-5E-6F'
 
 
 # See if we're connected to them
-CONNECTED=`system_profiler SPBluetoothDataType | awk "/$MACADDR/ {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
+CONNECTED=`system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
 if [ $CONNECTED ]; then
 	BTDATA=`defaults read /Library/Preferences/com.apple.Bluetooth | awk "/\"$MACADDR\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}"`
 


### PR DESCRIPTION
This commit updates the logic used to parse system_profiler and
com.apple.Bluetooth data to use awk as opposed to pcrgrep. awk is a
command line tool found on MacOS by default where pcregrep is a tool
which needs to be installed from an external source.

The AirPodsPower.sh script performs and functions the same as before but
this commit should allow for users to more easily install and use the
script.

This commit PR also updates the default MACADDR variable to feature a dummy MAC address, and expands the MAC address to be searched regardless of user input casing.