### PR TITLE
Update AirPodsPower.sh to support other headphones

### DIFF
--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Duckie's heaps mad AirPods Power Script.  Version 1
+# Duckie's heaps mad W1-enabled Headphone Power Script.  Version 1
+# Contributors: ankushg
 # Check http://blog.duklabs.com/airpods-power-in-touchbar/ for more info.
 
 
-# Put the Mac Address of your AirPods in here.
+# Put the Mac Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
 
 
@@ -11,13 +12,24 @@ MACADDR='7c-04-d0-af-88-62'
 CONNECTED=`system_profiler SPBluetoothDataType | /usr/local/bin/pcregrep -Mi "$MACADDR(\n.*){6}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
 if [ $CONNECTED ]; then
 	BTDATA=`defaults read /Library/Preferences/com.apple.Bluetooth | /usr/local/bin/pcregrep -Mi "\"$MACADDR\".=\s*\{[^\}]*\}"`
-
+	
+	COMBINEDBATT=`echo "$BTDATA" | grep BatteryPercentCombined | sed 's/.*BatteryPercentCombined = //' | sed 's/;//'` 
+	HEADSETBATT=`echo "$BTDATA" | grep HeadsetBattery | sed 's/.*HeadsetBattery = //' | sed 's/;//'` 
+	SINGLEBATT=`echo "$BTDATA" | grep BatteryPercentSingle | sed 's/.*BatteryPercentSingle = //' | sed 's/;//'` 
 	CASEBATT=`echo "$BTDATA" | grep BatteryPercentCase | sed 's/.*BatteryPercentCase = //' | sed 's/;//'` 
 	LEFTBATT=`echo "$BTDATA" | grep BatteryPercentLeft | sed 's/.*BatteryPercentLeft = //' | sed 's/;//'` 
 	RIGHTBATT=`echo "$BTDATA" | grep BatteryPercentRight | sed 's/.*BatteryPercentRight = //' | sed 's/;//'` 
 
-	echo "🎧 L: $LEFTBATT% R: $RIGHTBATT% C: $CASEBATT%"
+	output="🎧"
+	[[ !  -z  $COMBINEDBATT  ]] && output="$output $COMBINEDBATT%"
+	[[ !  -z  $HEADSETBATT  ]] && output="$output $HEADSETBATT%"
+	[[ !  -z  $SINGLEBATT  ]] && output="$output $SINGLEBATT%"
+	[[ !  -z  $LEFTBATT  ]] && output="$output L: $LEFTBATT%"
+	[[ !  -z  $RIGHTBATT  ]] && output="$output R: $RIGHTBATT%"
+	[[ !  -z  $CASEBATT  ]] && output="$output C: $CASEBATT%"
+	
+	echo $output
 else
-	echo "No AirPods"
+	echo "🎧 Not Connected"
 fi
 


### PR DESCRIPTION
Tested with my BeatsX, should support any headphones that report their battery to OS X (potentially more than just W1-enabled headphones)

For what it's worth, the only extra value needed to support BeatsX headphones was `BatteryPercentSingle`, but `BatteryPercentCombined` and `HeadsetBattery` are also listed as possible properties in the [`IOBlutoothDevice` headers](https://github.com/onmyway133/Runtime-Headers/blob/master/macOS/10.12/IOBluetooth.framework/IOBluetoothDevice.h), so I added them anyway 🤷‍♂️ 

