### PR TITLE
Adjustments and fixes for shell code

### DIFF
--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -14,8 +14,8 @@ CONNECTED=$(system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=
 
 if [[ "${CONNECTED}" ]]; then
   for i in "${VARIABLES[@]}"; do
-    declare -x "${i}"="$(grep "${i}" <<< "${BTDATA}")|sed 's/.*${i} = //'|sed 's/;//')"
-    [[ ! -z "${$i}" ]] && OUTPUT="${OUTPUT} ${$i}%"
+    declare -x "${i}"="$(grep "${i}" <<< "${BTDATA}"|sed "s/.*${i} = //"|sed 's/;//')"
+    [[ ! -z "${!i}" ]] && OUTPUT="${OUTPUT} ${!i}%"
   done
   printf "%s\\n" "${OUTPUT}"
 else

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -3,19 +3,17 @@
 # Contributors: ankushg, spetykowski, danozdotnet
 # Check http://blog.duklabs.com/airpods-power-in-touchbar/ for more info.
 
-# Put the Mac Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
+# Put the MAC Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
-
-# Don't edit anything below this line ;)
 OUTPUT='🎧'
 VARIABLES=("BatteryPercentCombined" "HeadsetBattery" "BatteryPercentSingle" "BatteryPercentCase" "BatteryPercentLeft" "BatteryPercentRight")
-BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}')
-CONNECTED=$(system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/')
+BTDATA=$(awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}'<<<defaults read /Library/Preferences/com.apple.Bluetooth)
+CONNECTED=$(awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}"<<<system_profiler SPBluetoothDataType|grep "Connected: Yes"|sed 's/.*Connected: Yes/1/')
 
 if [[ "${CONNECTED}" ]]; then
   for i in "${VARIABLES[@]}"; do
-    declare -x "${i}"="$(grep "${i}" <<< "${BTDATA}"|sed "s/.*${i} = //"|sed 's/;//')"
-    [[ ! -z "${!i}" ]] && OUTPUT="${OUTPUT} ${!i}%"
+    declare -x "${i}"="$(grep "${i}"<<<"${BTDATA}"|sed "s/.*${i} = //"|sed 's/;//')"
+    [[ ! -z "${!i}" ]] && OUTPUT="${OUTPUT} $(awk '/BatteryPercent/{print substr($0,15,1)": "}'<<<${i})${!i}%"
   done
   printf "%s\\n" "${OUTPUT}"
 else

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -5,28 +5,29 @@
 
 # Put the Mac Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
+ICON='\xf0\x9f\x8e\xa7'
 
 # See if we're connected to them
 CONNECTED=$(system_profiler SPBluetoothDataType|awk "/${MACADDR}/i {for(i=1; i<=6; i++) {getline; print}}"|grep "Connected: Yes"|sed 's/.*Connected: Yes/1/')
 if [[ "${CONNECTED}" ]]; then
-  BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk "/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}")
+  BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}')
 
   COMBINEDBATT=$(grep "BatteryPercentCombined" <<< "${BTDATA}"|sed 's/.*BatteryPercentCombined = //'|sed 's/;//')
   HEADSETBATT=$(grep "HeadsetBattery" <<< "${BTDATA}"|sed 's/.*HeadsetBattery = //'|sed 's/;//')
   SINGLEBATT=$(grep "BatteryPercentSingle" <<< "${BTDATA}"|sed 's/.*BatteryPercentSingle = //'|sed 's/;//')
   CASEBATT=$(grep "BatteryPercentCase" <<< "${BTDATA}"|sed 's/.*BatteryPercentCase = //'|sed 's/;//')
-  LEFTBATT=$(grep "BatteryPercentLeft" <<< "${BTDATA}"|sed 's/.*BatteryPercentLeft = //'|sed 's/;//') 
+  LEFTBATT=$(grep "BatteryPercentLeft" <<< "${BTDATA}"|sed 's/.*BatteryPercentLeft = //'|sed 's/;//')
   RIGHTBATT=$(grep "BatteryPercentRight" <<< "${BTDATA}"|sed 's/.*BatteryPercentRight = //'|sed 's/;//')
 
-  OUTPUT="🎧"
+  OUTPUT="${ICON}"
   [[ ! -z "${COMBINEDBATT}" ]] && OUTPUT="${OUTPUT} ${COMBINEDBATT}%"
   [[ ! -z "${HEADSETBATT}" ]] && OUTPUT="${OUTPUT} ${HEADSETBATT}%"
   [[ ! -z "${SINGLEBATT}" ]] && OUTPUT="${OUTPUT} ${SINGLEBATT}%"
-  [[ ! -z "${LEFTBATT}" ]] && OUTPUT="${OUTPUT} L: ${LEFTBATT}%"
+  [[ ! -z "${LEFTBATT}" ]] 	&& OUTPUT="${OUTPUT} L: ${LEFTBATT}%"
   [[ ! -z "${RIGHTBATT}" ]] && OUTPUT="${OUTPUT} R: ${RIGHTBATT}%"
-  [[ ! -z "${CASEBATT}" ]] && OUTPUT="${OUTPUT} C: ${CASEBATT}%"
+  [[ ! -z "${CASEBATT}" ]] 	&& OUTPUT="${OUTPUT} C: ${CASEBATT}%"
 
-  echo "${OUTPUT}"
+  printf "%s\\n" "${OUTPUT}"
 else
-  echo "🎧 Not Connected"
+  printf "%s Not Connected\\n" "${ICON}"
 fi

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -7,7 +7,7 @@
 MACADDR='7c-04-d0-af-88-62'
 
 # Don't edit anything below this line ;)
-OUTPUT='\xf0\x9f\x8e\xa7'
+OUTPUT='🎧'
 VARIABLES=("BatteryPercentCombined" "HeadsetBattery" "BatteryPercentSingle" "BatteryPercentCase" "BatteryPercentLeft" "BatteryPercentRight")
 BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}')
 CONNECTED=$(system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/')

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -19,12 +19,12 @@ if [[ "${CONNECTED}" ]]; then
   RIGHTBATT=$(grep "BatteryPercentRight" <<< "${BTDATA}"|sed 's/.*BatteryPercentRight = //'|sed 's/;//')
 
   OUTPUT="🎧"
-  [[ ! -z "${COMBINEDBATT}" ]] && output="${OUTPUT} ${COMBINEDBATT}%"
-  [[ ! -z "${HEADSETBATT}" ]] && output="${OUTPUT} ${HEADSETBATT}%"
-  [[ ! -z "${SINGLEBATT}" ]] && output="${OUTPUT} ${SINGLEBATT}%"
-  [[ ! -z "${LEFTBATT}" ]] && output="${OUTPUT} L: ${LEFTBATT}%"
-  [[ ! -z "${RIGHTBATT}" ]] && output="${OUTPUT} R: ${RIGHTBATT}%"
-  [[ ! -z "${CASEBATT}" ]] && output="${OUTPUT} C: ${CASEBATT}%"
+  [[ ! -z "${COMBINEDBATT}" ]] && OUTPUT="${OUTPUT} ${COMBINEDBATT}%"
+  [[ ! -z "${HEADSETBATT}" ]] && OUTPUT="${OUTPUT} ${HEADSETBATT}%"
+  [[ ! -z "${SINGLEBATT}" ]] && OUTPUT="${OUTPUT} ${SINGLEBATT}%"
+  [[ ! -z "${LEFTBATT}" ]] && OUTPUT="${OUTPUT} L: ${LEFTBATT}%"
+  [[ ! -z "${RIGHTBATT}" ]] && OUTPUT="${OUTPUT} R: ${RIGHTBATT}%"
+  [[ ! -z "${CASEBATT}" ]] && OUTPUT="${OUTPUT} C: ${CASEBATT}%"
 
   echo "${OUTPUT}"
 else

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -1,35 +1,32 @@
 #!/bin/bash
 # Duckie's heaps mad W1-enabled Headphone Power Script.  Version 1
-# Contributors: ankushg, spetykowski
+# Contributors: ankushg, spetykowski, danozdotnet
 # Check http://blog.duklabs.com/airpods-power-in-touchbar/ for more info.
-
-
 
 # Put the Mac Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
 
 # See if we're connected to them
-CONNECTED=`system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/'`
-if [ $CONNECTED ]; then
-	BTDATA=`defaults read /Library/Preferences/com.apple.Bluetooth | awk "/\"$MACADDR\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}"`
-	
-  COMBINEDBATT=`echo "$BTDATA" | grep BatteryPercentCombined | sed 's/.*BatteryPercentCombined = //' | sed 's/;//'` 
-	HEADSETBATT=`echo "$BTDATA" | grep HeadsetBattery | sed 's/.*HeadsetBattery = //' | sed 's/;//'` 
-	SINGLEBATT=`echo "$BTDATA" | grep BatteryPercentSingle | sed 's/.*BatteryPercentSingle = //' | sed 's/;//'` 
-  CASEBATT=`echo "$BTDATA" | grep BatteryPercentCase | sed 's/.*BatteryPercentCase = //' | sed 's/;//'` 
-	LEFTBATT=`echo "$BTDATA" | grep BatteryPercentLeft | sed 's/.*BatteryPercentLeft = //' | sed 's/;//'` 
-	RIGHTBATT=`echo "$BTDATA" | grep BatteryPercentRight | sed 's/.*BatteryPercentRight = //' | sed 's/;//'` 
+CONNECTED=$(system_profiler SPBluetoothDataType|awk "/${MACADDR}/i {for(i=1; i<=6; i++) {getline; print}}"|grep "Connected: Yes"|sed 's/.*Connected: Yes/1/')
+if [[ "${CONNECTED}" ]]; then
+  BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk "/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}")
 
-	output="🎧"
-	[[ !  -z  $COMBINEDBATT  ]] && output="$output $COMBINEDBATT%"
-	[[ !  -z  $HEADSETBATT  ]] && output="$output $HEADSETBATT%"
-	[[ !  -z  $SINGLEBATT  ]] && output="$output $SINGLEBATT%"
-	[[ !  -z  $LEFTBATT  ]] && output="$output L: $LEFTBATT%"
-	[[ !  -z  $RIGHTBATT  ]] && output="$output R: $RIGHTBATT%"
-	[[ !  -z  $CASEBATT  ]] && output="$output C: $CASEBATT%"
-	
-	echo $output
+  COMBINEDBATT=$(grep "BatteryPercentCombined" <<< "${BTDATA}"|sed 's/.*BatteryPercentCombined = //'|sed 's/;//')
+  HEADSETBATT=$(grep "HeadsetBattery" <<< "${BTDATA}"|sed 's/.*HeadsetBattery = //'|sed 's/;//')
+  SINGLEBATT=$(grep "BatteryPercentSingle" <<< "${BTDATA}"|sed 's/.*BatteryPercentSingle = //'|sed 's/;//')
+  CASEBATT=$(grep "BatteryPercentCase" <<< "${BTDATA}"|sed 's/.*BatteryPercentCase = //'|sed 's/;//')
+  LEFTBATT=$(grep "BatteryPercentLeft" <<< "${BTDATA}"|sed 's/.*BatteryPercentLeft = //'|sed 's/;//') 
+  RIGHTBATT=$(grep "BatteryPercentRight" <<< "${BTDATA}"|sed 's/.*BatteryPercentRight = //'|sed 's/;//')
+
+  OUTPUT="🎧"
+  [[ ! -z "${COMBINEDBATT}" ]] && output="${OUTPUT} ${COMBINEDBATT}%"
+  [[ ! -z "${HEADSETBATT}" ]] && output="${OUTPUT} ${HEADSETBATT}%"
+  [[ ! -z "${SINGLEBATT}" ]] && output="${OUTPUT} ${SINGLEBATT}%"
+  [[ ! -z "${LEFTBATT}" ]] && output="${OUTPUT} L: ${LEFTBATT}%"
+  [[ ! -z "${RIGHTBATT}" ]] && output="${OUTPUT} R: ${RIGHTBATT}%"
+  [[ ! -z "${CASEBATT}" ]] && output="${OUTPUT} C: ${CASEBATT}%"
+
+  echo "${OUTPUT}"
 else
-	echo "🎧 Not Connected"
+  echo "🎧 Not Connected"
 fi
-

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -5,29 +5,19 @@
 
 # Put the Mac Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
-ICON='\xf0\x9f\x8e\xa7'
 
-# See if we're connected to them
-CONNECTED=$(system_profiler SPBluetoothDataType|awk "/${MACADDR}/i {for(i=1; i<=6; i++) {getline; print}}"|grep "Connected: Yes"|sed 's/.*Connected: Yes/1/')
+# Don't edit anything below this line ;)
+OUTPUT='\xf0\x9f\x8e\xa7'
+VARIABLES=("BatteryPercentCombined" "HeadsetBattery" "BatteryPercentSingle" "BatteryPercentCase" "BatteryPercentLeft" "BatteryPercentRight")
+BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}')
+CONNECTED=$(system_profiler SPBluetoothDataType | awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}" | grep "Connected: Yes" | sed 's/.*Connected: Yes/1/')
+
 if [[ "${CONNECTED}" ]]; then
-  BTDATA=$(defaults read /Library/Preferences/com.apple.Bluetooth|awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}')
-
-  COMBINEDBATT=$(grep "BatteryPercentCombined" <<< "${BTDATA}"|sed 's/.*BatteryPercentCombined = //'|sed 's/;//')
-  HEADSETBATT=$(grep "HeadsetBattery" <<< "${BTDATA}"|sed 's/.*HeadsetBattery = //'|sed 's/;//')
-  SINGLEBATT=$(grep "BatteryPercentSingle" <<< "${BTDATA}"|sed 's/.*BatteryPercentSingle = //'|sed 's/;//')
-  CASEBATT=$(grep "BatteryPercentCase" <<< "${BTDATA}"|sed 's/.*BatteryPercentCase = //'|sed 's/;//')
-  LEFTBATT=$(grep "BatteryPercentLeft" <<< "${BTDATA}"|sed 's/.*BatteryPercentLeft = //'|sed 's/;//')
-  RIGHTBATT=$(grep "BatteryPercentRight" <<< "${BTDATA}"|sed 's/.*BatteryPercentRight = //'|sed 's/;//')
-
-  OUTPUT="${ICON}"
-  [[ ! -z "${COMBINEDBATT}" ]] && OUTPUT="${OUTPUT} ${COMBINEDBATT}%"
-  [[ ! -z "${HEADSETBATT}" ]] && OUTPUT="${OUTPUT} ${HEADSETBATT}%"
-  [[ ! -z "${SINGLEBATT}" ]] && OUTPUT="${OUTPUT} ${SINGLEBATT}%"
-  [[ ! -z "${LEFTBATT}" ]] 	&& OUTPUT="${OUTPUT} L: ${LEFTBATT}%"
-  [[ ! -z "${RIGHTBATT}" ]] && OUTPUT="${OUTPUT} R: ${RIGHTBATT}%"
-  [[ ! -z "${CASEBATT}" ]] 	&& OUTPUT="${OUTPUT} C: ${CASEBATT}%"
-
+  for i in "${VARIABLES[@]}"; do
+    declare -x "${i}"="$(grep "${i}" <<< "${BTDATA}")|sed 's/.*${i} = //'|sed 's/;//')"
+    [[ ! -z "${$i}" ]] && OUTPUT="${OUTPUT} ${$i}%"
+  done
   printf "%s\\n" "${OUTPUT}"
 else
-  printf "%s Not Connected\\n" "${ICON}"
+  printf "%s Not Connected\\n" "${OUTPUT}"
 fi

--- a/AirPodsPower.sh
+++ b/AirPodsPower.sh
@@ -5,15 +5,15 @@
 
 # Put the MAC Address of your W1-enabled headphones (Apple AirPods, Beats Solo3, Powerbeats3, BeatsX) in here.
 MACADDR='7c-04-d0-af-88-62'
-OUTPUT='🎧'
+OUTPUT='🎧'; BLUETOOTH_DEFAULTS=$(defaults read /Library/Preferences/com.apple.Bluetooth); SYSTEM_PROFILER=$(system_profiler SPBluetoothDataType)
 VARIABLES=("BatteryPercentCombined" "HeadsetBattery" "BatteryPercentSingle" "BatteryPercentCase" "BatteryPercentLeft" "BatteryPercentRight")
-BTDATA=$(awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}'<<<defaults read /Library/Preferences/com.apple.Bluetooth)
-CONNECTED=$(awk "/$MACADDR/i {for(i=1; i<=6; i++) {getline; print}}"<<<system_profiler SPBluetoothDataType|grep "Connected: Yes"|sed 's/.*Connected: Yes/1/')
+BTDATA=$(awk '/\"${MACADDR}\".=\s*\{[^\}]*\}/i {for(i=1; i<=6; i++) {getline; print}}' <<< "${BLUETOOTH_DEFAULTS}" )
+CONNECTED=$(awk "/${MACADDR}/i {for(i=1; i<=6; i++) {getline; print}}" <<< "${SYSTEM_PROFILER}" |awk '/Connected: Yes/{print 1}')
 
 if [[ "${CONNECTED}" ]]; then
-  for i in "${VARIABLES[@]}"; do
-    declare -x "${i}"="$(grep "${i}"<<<"${BTDATA}"|sed "s/.*${i} = //"|sed 's/;//')"
-    [[ ! -z "${!i}" ]] && OUTPUT="${OUTPUT} $(awk '/BatteryPercent/{print substr($0,15,1)": "}'<<<${i})${!i}%"
+  for I in "${VARIABLES[@]}"; do
+    declare -x "${I}"="$(grep "${I}"<<<"${BTDATA}"|sed "s/.*${I} = //"|sed 's/;//')"
+    [[ ! -z "${!I}" ]] && OUTPUT="${OUTPUT} $(awk '/BatteryPercent/{print substr($0,15,1)": "}'<<<"${I}")${!I}%"
   done
   printf "%s\\n" "${OUTPUT}"
 else


### PR DESCRIPTION
Adjusted variables to be all uppercase
Replaced backticks with correct command expansion using $(...)
Replaced echo $var|grep with bash here string: grep <<< $var
Minor cleanup of things here and there